### PR TITLE
Feature/add elb resource suppport

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,18 @@ custom:
       my-task-with-load-balancers:
         image: 123456789369.dkr.ecr.eu-west-1.amazonaws.com/my-image
         loadBalancers:
-          - port: 8080
-            arn: ${self:custom.httpTargetGroupArn}
-          - port 8443
-            arn: ${self:custom.httpsTargetGroupArn}
+          # You can use the arn of an existing target group already associated with a load balancer
+          - hostPort: 8080
+            containerPort: 8080
+            targetGroup: ${self:custom.httpTargetGroupArn}
+          # If you're using an ELB/target group that you're building in the Resources section of
+          # serverless.yml, you may run into an issue where the elb and default listener rule are
+          # not created prior to the target group/service. In this scenario you can specify the 
+          # logical name of the resource so that the appropriate dependencies can be set.
+          - hostPort: 8443
+            containerPort: 8443
+            targetGroup: ${self:custom.httpsTargetGroupArn} 
+            elbResource: "my-task-elb"
 ```
 
 Advanced usage

--- a/lib/index.js
+++ b/lib/index.js
@@ -174,14 +174,21 @@ class ServerlessFargateTasks {
         // Configure Load Balancers if defined.
         if(options.tasks[identifier].hasOwnProperty('loadBalancers')) {
           let loadBalancers = [];
+          let dependsOn = [];
           options.tasks[identifier]['loadBalancers'].forEach(item => {
             const loadBalancer = Object.assign({
               'ContainerName': name,
               'ContainerPort': item.containerPort,
-              'TargetGroupArn': item.arn
+              'TargetGroupArn': item.targetGroup
             });
             loadBalancers.push(loadBalancer);
+            if(item.hasOwnProperty('elbResource')) {
+              dependsOn.push(item.elbResource)
+            }
           });
+          if(dependsOn.length > 0) {
+            service['DependsOn'] = dependsOn;
+          }
           service['Properties']['LoadBalancers'] = loadBalancers;
         }
         template['Resources'][normalizedIdentifier + 'Service'] = service


### PR DESCRIPTION
Adds ability to specify a Resource Logical name for implementations that create load balancers and target groups within the resource sections of the serverless.yml file. This is important because the CloudFormation update task will fail if the referenced target group is not already associated with an existing ELB. Ultimately, we should probably weigh whether we want to

1) continue support in this manner.
2) configure the plugin such that a target group + elb are created VIA the plugin and disable support for pre-existing target groups
or
3) Find a way to both support existing target groups OR have the plugin create a new target group/elb pair and set dependencies accordingly.